### PR TITLE
Wrong query for propertyCondition in RestfulDataProviderEFQ.

### DIFF
--- a/plugins/restful/RestfulDataProviderEFQ.php
+++ b/plugins/restful/RestfulDataProviderEFQ.php
@@ -180,6 +180,10 @@ abstract class RestfulDataProviderEFQ extends \RestfulBase implements \RestfulDa
         }
       }
       else {
+        if (in_array(strtoupper($filter['operator'][0]), array('IN', 'BETWEEN'))) {
+          $query->propertyCondition($property_name, $filter['value'], $filter['operator'][0]);
+          continue;
+        }
         $column = $this->getColumnFromProperty($property_name);
         for ($index = 0; $index < count($filter['value']); $index++) {
           $query->propertyCondition($column, $filter['value'][$index], $filter['operator'][$index]);


### PR DESCRIPTION
When `$property_name` is a _field_ and the operator is either `IN`, `BETWEEN` we pass the array values as is to the `fieldCondition` function.

Same login should happen when `$property_name` is a _property_, otherwise we get:

```
SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax;
```

This PR is fixing that bug.
